### PR TITLE
Capturado el escenario de filtrar por empleado sin turnos

### DIFF
--- a/src/components/ownerPage/OwnerPage.jsx
+++ b/src/components/ownerPage/OwnerPage.jsx
@@ -15,6 +15,7 @@ const OwnerPage = () => {
     const [providerAppointments, setProviderAppointments] = useState("");
     const [providerFlag, setProviderFlag] = useState(false);
     const [showProvList, setShowProvList] = useState(false);
+    //const [emptyProvList, setEmptyProvList] = useState(false);
 
     const { token, user } = useContext(AuthenticationContext);
     const { myShopAppointments, myShopEmployees, reqEmpHandler, reqAppHandler, reqLastAppHandler } = useContext(ShopContext);
@@ -81,6 +82,23 @@ const OwnerPage = () => {
         setShowProvList(true)
     };
 
+    const validateEmptyProvArray = (provArray) => {
+        if (provArray == "Aun no posee turnos") {
+            return (
+                <div className="no-appointments-container">
+                    <h3 className="no-appointments">El empleado aun no posee turnos asignados</h3>
+                </div>
+            )
+        } else {
+            return (
+                <OwnerAppointmentsList
+                    appointmentsArray={providerAppointments}
+                    employeesArray={myShopEmployees}
+                />
+            )
+        }
+    };
+
     const onClickShowAppByProvider = () => {
         if (!providerFlag) {
             setProviderFlag(true);
@@ -138,10 +156,7 @@ const OwnerPage = () => {
                         appointmentsArray={myShopAppointments}
                         employeesArray={myShopEmployees}
                     /> : ""}
-                    {showProvList ? <OwnerAppointmentsList
-                        appointmentsArray={providerAppointments}
-                        employeesArray={myShopEmployees}
-                    /> : ""}
+                    {showProvList ? validateEmptyProvArray(providerAppointments) : ""}
                 </div>
             </div>
         </>

--- a/src/components/ownerProviderButtonList/OwnerProviderButtonList.jsx
+++ b/src/components/ownerProviderButtonList/OwnerProviderButtonList.jsx
@@ -16,14 +16,26 @@ const OwnerProviderButtonList = ({ me, myShopEmployees, token, setProviderAppArr
                 if (response.ok) {
                     return response.json()
                 } else {
-                    throw new Error("The response has some errors");
+                    // Manejo de errores según el código de estado
+                    if (response.status === 404) {
+                        console.log("Sí, not found")
+                        setProviderAppArray("Aun no posee turnos")
+                        throw new Error('Not Found (404)');
+                    } else if (response.status === 401) {
+                        throw new Error('Unauthorized (401)');
+                    } else {
+                        throw new Error(`Error: ${response.status}`);
+                    }
                 }
             })
             .then((data) => {
                 console.log(`provider appointments: ${data}`);
                 setProviderAppArray(data);
             })
-            .catch((error) => console.log(error))
+            .catch((error) => {
+                setProviderAppArray("Aun no posee turnos")
+                console.log(error)
+            })
     };
 
     return (


### PR DESCRIPTION
En la sección del dueño, al filtrar los turnos por empleado, si el empleado había sido incorporado recientemente y hasta el momento no poseía turnos asignados, se ocasionaba un error. Fue corregido